### PR TITLE
Export IsRuleExist function

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -19,7 +19,7 @@ var rulesFuncMap = make(map[string]func(string, string, string, interface{}) err
 // fn func(name string, fn func(field string, rule string, message string, value interface{}) error
 // see example in readme: https://github.com/thedevsaddam/govalidator#add-custom-rules
 func AddCustomRule(name string, fn func(field string, rule string, message string, value interface{}) error) {
-	if isRuleExist(name) {
+	if IsRuleExist(name) {
 		panic(fmt.Errorf("govalidator: %s is already defined in rules", name))
 	}
 	rulesFuncMap[name] = fn

--- a/utils.go
+++ b/utils.go
@@ -16,8 +16,8 @@ func isContainRequiredField(rules []string) bool {
 	return false
 }
 
-// isRuleExist check if the provided rule name is exist or not
-func isRuleExist(rule string) bool {
+// IsRuleExist check if the provided rule name is exist or not
+func IsRuleExist(rule string) bool {
 	if strings.Contains(rule, ":") {
 		rule = strings.Split(rule, ":")[0]
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -22,14 +22,14 @@ func Benchmark_isContainRequiredField(b *testing.B) {
 	}
 }
 
-func Test_isRuleExist(t *testing.T) {
-	if !isRuleExist("required") {
-		t.Error("isRuleExist failed for valid rule")
+func Test_IsRuleExist(t *testing.T) {
+	if !IsRuleExist("required") {
+		t.Error("IsRuleExist failed for valid rule")
 	}
-	if isRuleExist("not exist") {
-		t.Error("isRuleExist failed for invalid rule")
+	if IsRuleExist("not exist") {
+		t.Error("IsRuleExist failed for invalid rule")
 	}
-	if !isRuleExist("mime") {
+	if !IsRuleExist("mime") {
 		t.Error("extended rules failed")
 	}
 }

--- a/validator.go
+++ b/validator.go
@@ -88,7 +88,7 @@ func (v *Validator) Validate() url.Values {
 			continue
 		}
 		for _, rule := range rules {
-			if !isRuleExist(rule) {
+			if !IsRuleExist(rule) {
 				panic(fmt.Errorf("govalidator: %s is not a valid rule", rule))
 			}
 			msg := v.getCustomMessage(field, rule)
@@ -196,7 +196,7 @@ func (v *Validator) internalValidateStruct() url.Values {
 		}
 		value, _ := r.getFlatVal(field)
 		for _, rule := range rules {
-			if !isRuleExist(rule) {
+			if !IsRuleExist(rule) {
 				panic(fmt.Errorf("govalidator: %s is not a valid rule", rule))
 			}
 			msg := v.getCustomMessage(field, rule)


### PR DESCRIPTION
This PR exports the IsRuleExist function to check if the rule exists from the userland. A use case may be checking if a rule exists before calling the `AddCustomRule()` from the handler. Because a handler is executed on each request.