### PR TITLE
Allow removal of custom rule

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -25,6 +25,13 @@ func AddCustomRule(name string, fn func(field string, rule string, message strin
 	rulesFuncMap[name] = fn
 }
 
+// RemoveCustomRule removes an existing rule
+func RemoveCustomRule(name string) {
+	if IsRuleExist(name) {
+		delete(rulesFuncMap, name)
+	}
+}
+
 // validateCustomRules validate custom rules
 func validateCustomRules(field string, rule string, message string, value interface{}, errsBag url.Values) {
 	for k, v := range rulesFuncMap {

--- a/rules_test.go
+++ b/rules_test.go
@@ -2191,3 +2191,10 @@ func Test_NotIn_string_valid(t *testing.T) {
 		t.Error("not_in validation was triggered when valid!")
 	}
 }
+
+func Test_RemoveCustomRule(t *testing.T) {
+	RemoveCustomRule("__x__")
+	if _, ok := rulesFuncMap["__x__"]; ok {
+		t.Error("RemoveCustomRule failed to remove an existing rule")
+	}
+}


### PR DESCRIPTION
This PR allows the removal of an existing custom rule by introducing a new function: `RemoveCustomRule(name string)`